### PR TITLE
test[cypress]: add e2e testing coverage

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'cypress'
 
 export default defineConfig({
   e2e: {
+    baseUrl: 'https://distilled-countrypedia.vercel.app/',
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -1,5 +1,66 @@
-describe('template spec', () => {
-  it('passes', () => {
-    cy.visit('https://example.cypress.io')
+describe('Visit Countrypedia website', () => {
+  it('should visit the homepage', () => {
+    cy.visitWebsite()
   })
 })
+
+describe('Country Cards Count Test', () => {
+  it('should count the number of Country Cards elements on the page', () => {
+    cy.visitWebsite()
+    cy.get('a')
+      .its('length')
+      .then((count) => {
+        expect(count).to.equal(250)
+        cy.log(`Number of anchor tags: ${count}`)
+      })
+  })
+})
+
+describe('Search and Select functionality', () => {
+  beforeEach(() => {
+    cy.visitWebsite()
+  })
+
+  it('should search for "Ireland" and find a matching card with the correct attributes', () => {
+    cy.searchAndAssertCountry('IRL', 'Ireland', 'https://flagcdn.com/ie.svg')
+  })
+})
+
+describe('Search and Select a Different Country', () => {
+  beforeEach(() => {
+    cy.visitWebsite()
+  })
+
+  it('should search for "Brazil" and find a matching card with the correct attributes', () => {
+    cy.searchAndAssertCountry('BRA', 'Brazil', 'https://flagcdn.com/br.svg')
+  })
+})
+
+describe('Search and click and Go Back', () => {
+  beforeEach(() => {
+    cy.visitWebsite()
+  })
+
+  it('should search for "Ireland", find a matching card, click it, navigate to the country page, click the back button, and navigate to the home page', () => {
+    cy.searchAndAssertCountry('IRL', 'Ireland', 'https://flagcdn.com/ie.svg')
+    cy.clickCountryCard('IRL', 'https://distilled-countrypedia.vercel.app/irl')
+    cy.get('a.page_goBackLink__piZpn').click()
+    cy.url().should('eq', 'https://distilled-countrypedia.vercel.app/')
+  })
+})
+
+describe('Border country presence test', () => {
+  beforeEach(() => {
+    cy.visitWebsite()
+  })
+
+  it('should check if the border country "United Kingdom" is present and navigate to the expected URL', () => {
+    cy.searchAndAssertCountry(
+      'GBR',
+      'United Kingdom',
+      'https://flagcdn.com/gb.svg',
+    )
+    cy.clickCountryCard('GBR', 'https://distilled-countrypedia.vercel.app/gbr')
+  })
+})
+export {}

--- a/cypress/integration/e2e.spec.ts
+++ b/cypress/integration/e2e.spec.ts
@@ -1,6 +1,0 @@
-describe('Visit Countrypedia website', () => {
-  it('should visit the homepage and assert a condition', () => {
-    cy.visit('https://')
-    cy.contains('Welcome to Example').should('be.visible')
-  })
-})

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,37 +1,46 @@
 /// <reference types="cypress" />
-// ***********************************************
-// This example commands.ts shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-//
-// declare global {
-//   namespace Cypress {
-//     interface Chainable {
-//       login(email: string, password: string): Chainable<void>
-//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
-//     }
-//   }
-// }
+/// Define a custom command to visit the website
+declare global {
+  namespace Cypress {
+    interface Chainable<Subject> {
+      visitWebsite(): Chainable<Window>
+      searchAndAssertCountry(
+        countryCode: string,
+        countryName: string,
+        flagUrl: string,
+      ): Chainable<Element>
+      clickCountryCard(
+        countryCode: string,
+        expectedUrl: string,
+      ): Chainable<Element>
+    }
+  }
+}
+
+
+Cypress.Commands.add('visitWebsite', () => {
+  cy.visit('/')
+  cy.contains('Countrypedia').should('be.visible')
+})
+
+// Define a custom command to search for a country and assert its attributes
+Cypress.Commands.add(
+  'searchAndAssertCountry',
+  (countryCode, countryName, flagUrl) => {
+    cy.get('#search-input').type(countryName)
+    cy.wait(2000)
+    cy.get(`a#${countryCode}`)
+      .find('img')
+      .should('have.attr', 'alt', `${countryName}`)
+      .and('have.attr', 'src', `${flagUrl}`)
+  },
+)
+
+// Define a custom command to click on a country card and assert the URL
+Cypress.Commands.add('clickCountryCard', (countryCode, expectedUrl) => {
+  cy.get(`a#${countryCode}`).click()
+  cy.url().should('eq', expectedUrl)
+})
+
+export {}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "typescript": "5.0.4"
       },
       "devDependencies": {
+        "@types/cypress": "^1.1.3",
         "cypress": "^12.12.0",
         "eslint": "^8.40.0",
         "eslint-config-prettier": "^8.8.0",
@@ -707,6 +708,16 @@
       "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/cypress": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-1.1.3.tgz",
+      "integrity": "sha512-OXe0Gw8LeCflkG1oPgFpyrYWJmEKqYncBsD/J0r17r0ETx/TnIGDNLwXt/pFYSYuYTpzcq1q3g62M9DrfsBL4g==",
+      "deprecated": "This is a stub types definition for cypress (https://cypress.io). cypress provides its own type definitions, so you don't need @types/cypress installed!",
+      "dev": true,
+      "dependencies": {
+        "cypress": "*"
       }
     },
     "node_modules/@types/hoist-non-react-statics": {
@@ -6264,6 +6275,15 @@
       "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
       "requires": {
         "tslib": "^2.4.0"
+      }
+    },
+    "@types/cypress": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-1.1.3.tgz",
+      "integrity": "sha512-OXe0Gw8LeCflkG1oPgFpyrYWJmEKqYncBsD/J0r17r0ETx/TnIGDNLwXt/pFYSYuYTpzcq1q3g62M9DrfsBL4g==",
+      "dev": true,
+      "requires": {
+        "cypress": "*"
       }
     },
     "@types/hoist-non-react-statics": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typescript": "5.0.4"
   },
   "devDependencies": {
+    "@types/cypress": "^1.1.3",
     "cypress": "^12.12.0",
     "eslint": "^8.40.0",
     "eslint-config-prettier": "^8.8.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "cypress/support/commands.js"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This commit adds an e2e testing using cypress:
The following scenarios were tested: 
- Visit the website 
- Check if all countries are fetched
- Search and select a country
- Search and select a different country 
- Search and click go back button 
- Check border country of a given country 